### PR TITLE
Use ensure_resource on /etc/ssh/ssh_known_hosts

### DIFF
--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -40,9 +40,10 @@ class ansible::master {
 
   # Fix /etc/ssh/ssh_known_hosts permission
   # See http://projects.puppetlabs.com/issues/2014
-  file { '/etc/ssh/ssh_known_hosts' :
-      ensure  => file,
-      mode    => '0644'
-  }
+  ensure_resource('file', '/etc/ssh/ssh_known_hosts', {
+      'ensure'  => 'file',
+      'mode'    => '0644',
+    }
+  )
 
 }


### PR DESCRIPTION
If you want to have this in places other than in the master, you need to
sure it's only used in one place.  This allows changing ssh_known_hosts
on other nodes without breaking this module
