### PR TITLE
Allow disabling package installs

### DIFF
--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -17,13 +17,17 @@
 #
 #  include ansible::master
 #
-class ansible::master {
+class ansible::master(
+  $manage_packages = true,
+) {
 
   # Create ansible user
   include ansible::user
 
   # Install Ansible
-  include ansible::install
+  if $manage_packages {
+    include ansible::install
+  }
 
   # Export ansible user public key if fact is defined
   if ( $::ansible_user_key != undef ) {


### PR DESCRIPTION
This is useful if you want to use the package repositories published by
Ansible, Inc.  You can then set manage_packages to false and do it
yourself.
