### PR TITLE
Sudo configurable

### DIFF
--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -23,6 +23,14 @@
 #   **automatic** : install ansible via the appropriate platform provider
 #   **manual** : don't install anything
 #
+# [*sudo*]
+# Set to 'disable' if you don't want to authorize ansible user to behave like
+# root (**Default: enable**) (**boolean**)
+#
+# [*manage_ssh_known_hosts*]
+# manage /etc/ssh/ssh_known_hosts file.
+# (**Default: true**) (**boolean**)
+#
 # == Examples
 #
 # === Deploy an ansible master
@@ -43,14 +51,25 @@
 #
 class ansible::master(
   $provider = 'pip',
+  $sudo = 'enable',
   $manage_ssh_known_hosts = 'true',
+  $manage_user = 'true',
   ){
 
   include ansible::params
 
+  if (not is_bool($ansible::user::manage_user)) {
+    fail('parameter "manage_user" must be true or false')
+  }
+  if (not is_bool($ansible::user::manage_sh_known_hosts) {
+    fail('parameter "manage_ssh_known_hosts" must be true or false')
+  }
+
   # Create ansible user with sudo
-  class { 'ansible::user' :
-    sudo => 'enable'
+  if ($ansible::user::manage_user) {
+    class { 'ansible::user' :
+      sudo => $ansible::user::sudo,
+    }
   }
 
   # Install Ansible

--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -52,8 +52,8 @@
 class ansible::master(
   $provider = 'pip',
   $sudo = 'enable',
-  $manage_ssh_known_hosts = 'true',
-  $manage_user = 'true',
+  $manage_ssh_known_hosts = true,
+  $manage_user = true,
   ){
 
   include ansible::params

--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -42,7 +42,8 @@
 # }
 #
 class ansible::master(
-  $provider = 'pip'
+  $provider = 'pip',
+  $manage_ssh_known_hosts = 'true',
   ){
 
   include ansible::params
@@ -85,10 +86,12 @@ class ansible::master(
 
   # Fix /etc/ssh/ssh_known_hosts permission
   # See http://projects.puppetlabs.com/issues/2014
-  ensure_resource('file', '/etc/ssh/ssh_known_hosts', {
-      'ensure'  => 'file',
-      'mode'    => '0644',
-    }
-  )
+  if ($manage_ssh_known_hosts) {
+    ensure_resource('file', '/etc/ssh/ssh_known_hosts', {
+        'ensure'  => 'file',
+        'mode'    => '0644',
+      }
+    )
+  }
 
 }

--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -58,11 +58,11 @@ class ansible::master(
 
   include ansible::params
 
-  validate_bool($ansible::user::manage_user)
-  validate_bool($ansible::user::manage_sh_known_hosts)
+  validate_bool($ansible::master::manage_user)
+  validate_bool($ansible::master::manage_sh_known_hosts)
 
   # Create ansible user with sudo
-  if ($ansible::user::manage_user) {
+  if ($ansible::master::manage_user) {
     class { 'ansible::user' :
       sudo => $ansible::user::sudo,
     }

--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -59,7 +59,7 @@ class ansible::master(
   include ansible::params
 
   validate_bool($ansible::master::manage_user)
-  validate_bool($ansible::master::manage_sh_known_hosts)
+  validate_bool($ansible::master::manage_ssh_known_hosts)
 
   # Create ansible user with sudo
   if ($ansible::master::manage_user) {

--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -58,12 +58,8 @@ class ansible::master(
 
   include ansible::params
 
-  if (not is_bool($ansible::user::manage_user)) {
-    fail('parameter "manage_user" must be true or false')
-  }
-  if (not is_bool($ansible::user::manage_sh_known_hosts)) {
-    fail('parameter "manage_ssh_known_hosts" must be true or false')
-  }
+  validate_bool($ansible::user::manage_user)
+  validate_bool($ansible::user::manage_sh_known_hosts)
 
   # Create ansible user with sudo
   if ($ansible::user::manage_user) {

--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -61,7 +61,7 @@ class ansible::master(
   if (not is_bool($ansible::user::manage_user)) {
     fail('parameter "manage_user" must be true or false')
   }
-  if (not is_bool($ansible::user::manage_sh_known_hosts) {
+  if (not is_bool($ansible::user::manage_sh_known_hosts)) {
     fail('parameter "manage_ssh_known_hosts" must be true or false')
   }
 

--- a/manifests/node.pp
+++ b/manifests/node.pp
@@ -18,6 +18,10 @@
 # [*master*]
 # The fqdn of the master host (**string**) (**required**)
 #
+# [*sudo*]
+# Set to 'disable' if you don't want to authorize ansible user to behave like
+# root (**boolean**) (**optional**)
+#
 # == Example
 #
 # class { 'ansible::node' :
@@ -26,12 +30,16 @@
 #
 class ansible::node(
   $master = 'none'
+  $sudo   = 'enable'
   ){
 
   include ansible::params
 
   if $ansible::node::master == 'none' {
     fail('master parameter must be set')
+  }
+  if ($ansible::node::sudo != 'enable' and $ansible::node::sudo != 'disable') {
+    fail('sudo parameter must be "enable" or "disable"')
   }
 
   # Export host key to store config
@@ -47,7 +55,7 @@ class ansible::node(
 
   # Create ansible user with sudo
   class { 'ansible::user' :
-    sudo => 'enable'
+    sudo => $ansible::node::sudo
   }
 
 }

--- a/manifests/node.pp
+++ b/manifests/node.pp
@@ -29,8 +29,8 @@
 # }
 #
 class ansible::node(
-  $master = 'none'
-  $sudo   = 'enable'
+  $master = 'none',
+  $sudo   = 'enable',
   ){
 
   include ansible::params

--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -42,37 +42,38 @@
 #
 class ansible::user(
   $sudo = 'disable',
-  $password = '*NP*'
+  $password = '*NP*',
+  $username = 'ansible',
 ) {
 
   include ansible::params
 
   # Create an 'ansible' user
-  user { 'ansible':
+  user { $ansible::user::username:
     ensure     => present,
     comment    => 'ansible',
     managehome => true,
     shell      => '/bin/bash',
-    home       => '/home/ansible',
+    home       => "/home/${ansible::user::username}",
     password   => $ansible::user::password
   }
 
   # Create a .ssh directory for the 'ansible' user
-  file { '/home/ansible/.ssh' :
+  file { "/home/${ansible::user::username}/.ssh" :
     ensure  => directory,
     mode    => '0700',
-    owner   => 'ansible',
-    group   => 'ansible',
-    require => User[ansible],
+    owner   => $ansible::user::username,
+    group   => $ansible::user::username,
+    require => User[$ansible::user::username],
     notify  => Exec[home_ansible_ssh_keygen]
   }
 
   # Generate rsa keys for the 'ansible' user
   exec { 'home_ansible_ssh_keygen':
     path    => ['/usr/bin'],
-    command => 'ssh-keygen -t rsa -q -f /home/ansible/.ssh/id_rsa -N ""',
-    creates => '/home/ansible/.ssh/id_rsa',
-    user    => 'ansible',
+    command => "ssh-keygen -t rsa -q -f /home/${ansible::user::username}/.ssh/id_rsa -N \"\"",
+    creates => "/home/${ansible::user::username}/.ssh/id_rsa",
+    user    => $ansible::user::username,
     require => Package['openssh-server']
   }
 

--- a/spec/classes/master_spec.rb
+++ b/spec/classes/master_spec.rb
@@ -19,6 +19,42 @@ describe 'ansible::master' do
 
   end
 
+  context "When you add an ansible::master class with manage_user disabled" do
+    let(:facts) { {:osfamily => 'Debian' } }
+    let(:params) { {:manage_user  => false} }
+
+    it { should_not contain_class('ansible::user')}
+    it { should contain_class('ansible::install') }
+    it { should contain_class('ansible::params') }
+
+    it '' do
+      should contain_file('/etc/ssh/ssh_known_hosts').with(
+        'ensure'  => 'file',
+        'path'    => '/etc/ssh/ssh_known_hosts',
+        'mode'    => '0644'
+      )
+    end
+
+  end
+
+  context "When you add an ansible::master class with sudo disabled" do
+    let(:facts) { {:osfamily => 'Debian' } }
+    let(:params) { {:sudo  => 'disable'} }
+
+    it { should contain_class('ansible::user').with('sudo' => 'disable')}
+    it { should contain_class('ansible::install') }
+    it { should contain_class('ansible::params') }
+
+    it '' do
+      should contain_file('/etc/ssh/ssh_known_hosts').with(
+        'ensure'  => 'file',
+        'path'    => '/etc/ssh/ssh_known_hosts',
+        'mode'    => '0644'
+      )
+    end
+
+  end
+
   context "When you add an ansible::master class with the manual provider" do
     let(:facts) { {:osfamily => 'Debian' } }
     let(:params) { {:provider  => 'manual'} } 

--- a/spec/classes/node_spec.rb
+++ b/spec/classes/node_spec.rb
@@ -18,6 +18,22 @@ describe 'ansible::node' do
 
   end
 
+  context 'When you add an ansible::node class without sudo' do
+    let(:facts) { {:osfamily => 'Debian' } }
+    let(:params) { {:master => 'host.fqdn.tld'} {:sudo => 'disable'} }
+
+    it { should contain_class('ansible::params') }
+
+    it { should contain_class('ansible::node').with(
+      'master' => 'host.fqdn.tld'
+    )}
+
+    it { should contain_class('ansible::user').with(
+      'sudo' => 'disable'
+    )}
+
+  end
+
   context 'When you add an ansible::node class without master parameter' do
     let(:facts) { {:osfamily => 'Debian' } }
 


### PR DESCRIPTION
Hi. I changed your puppet-ansible module to
* make the ansible user name configurable (or skip its creation at all)
* make the shipment of a sudoers file configurable
* add an option to manage the ssh_known_hosts file (with puppet 3.7.5 it causes an error)

Please consider to merge these changes. Thanks for your great work.
