### PR TITLE
made resource collection ID configurable

### DIFF
--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -59,9 +59,11 @@ class ansible::master(
 
   include ansible::params
 
-  # Create ansible user with sudo
-  class { 'ansible::user' :
-    sudo => 'enable'
+  if ! defined(Class['ansible::user']) {
+    # Create ansible user with sudo
+    class { 'ansible::user' :
+      sudo => 'enable'
+    }
   }
 
   # Install Ansible

--- a/manifests/node.pp
+++ b/manifests/node.pp
@@ -45,9 +45,11 @@ class ansible::node(
   # Authorize master host to connect via ssh by colleting its public key
   Ssh_authorized_key <<| tag == "ansible_master_${ansible::node::master}" |>>
 
-  # Create ansible user with sudo
-  class { 'ansible::user' :
-    sudo => 'enable'
+  if ! defined(Class['ansible::user']) {
+    # Create ansible user with sudo
+    class { 'ansible::user' :
+      sudo => 'enable'
+    }
   }
 
 }


### PR DESCRIPTION
if the ansible master has a hostname which is not known in advance, or can change, the resource collection ID should be configurable.

backward-compatible change for sake of api compatibility. I would have liked it to work out of the box with a preconfigured common collection id (e.g. "ansible" :) )