### PR TITLE
Add the possibility to override the package name

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -44,6 +44,7 @@
 # }
 #
 class ansible::install(
+  $package = ansible,
   $version = present,
   $provider= pip,
   ){
@@ -65,7 +66,7 @@ class ansible::install(
     }
   } else {
     # Install ansible with the default provider
-    package { 'ansible':
+    package { $ansible::install::package:
       ensure   => $ansible::install::version
     }
   }


### PR DESCRIPTION
This is needed to force the install of an Ansible 1.9 on RHEL where:
- the package named `ansible` is for Ansible 2.0.x
- the package named `ansible1.9` is for Ansible 1.9.x
