### PR TITLE
Fixed Case Quoting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,10 +11,13 @@ group :test do
   gem "rspec-puppet", '~> 1.0.0'
   gem "puppet-syntax", '~> 1.3.0'
   gem "puppetlabs_spec_helper", '~> 0.8.0'
+  if RUBY_VERSION =~ /^1/
+    gem "json_pure", '~> 1'
+  end
 end
 
 group :development do
-  if RUBY_VERSION !~ /^1.8/
+  if RUBY_VERSION !~ /^1/
     gem "guard-rake"
   end
 end

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -24,12 +24,12 @@ class ansible::params {
   }
 
   case $operatingsystemfamily {
-    Debian: {
+    'Debian': {
       $pip_dep_package = ['python-yaml','python-jinja2','python-paramiko',
       'python-pkg-resources','python-pip','python-crypto','python-markupsafe',
       'python-httplib2']
     }
-    Redhat: {
+    'Redhat': {
       $pip_dep_package = ['PyYAML','libyaml','python-babel','python-crypto',
       'python-ecdsa','python-httplib2','python-jinja2','python-keyczar',
       'python-markupsafe','python-paramiko','python-pyasn1','python-six',


### PR DESCRIPTION
On puppet<4 case values did not require quoting, on puppet 4 they do,
this change makes all versions of puppet be friendly.